### PR TITLE
PluginSecurityManager doesn't support Scala Enumerations

### DIFF
--- a/Scalatron/src/scalatron/scalatron/impl/ExecutionContextForUntrustedCode.scala
+++ b/Scalatron/src/scalatron/scalatron/impl/ExecutionContextForUntrustedCode.scala
@@ -112,6 +112,10 @@ object ExecutionContextForUntrustedCode
                                     // System.err.println("warning: granting permission to untrusted code: '%s'".format(permission))
                                     return // granted
 
+                                case "accessDeclaredMembers" =>
+                                  // this is triggered by Enumeration$$populateNameMap
+                                  return // granted
+
                                 case _ => // denied
                             }
 


### PR DESCRIPTION
**The Problem**

When running in "secure mode" you will get the following exception when trying to use a Scala Enumeration:

```
java.lang.SecurityException: Permission denied: (java.lang.RuntimePermission accessDeclaredMembers)
    at scalatron.scalatron.impl.ExecutionContextForUntrustedCode$PluginSecurityManager$2.check(ExecutionContextForUntrustedCode.scala:132)
    at scalatron.scalatron.impl.ExecutionContextForUntrustedCode$PluginSecurityManager$2.checkPermission(ExecutionContextForUntrustedCode.scala:80)
    at java.lang.SecurityManager.checkMemberAccess(SecurityManager.java:1662)
    at java.lang.Class.checkMemberAccess(Class.java:2157)
    at java.lang.Class.getDeclaredFields(Class.java:1742)
    at scala.Enumeration.scala$Enumeration$$populateNameMap(Enumeration.scala:160)
    at scala.Enumeration$$anonfun$scala$Enumeration$$nameOf$1.apply(Enumeration.scala:183)
    at scala.Enumeration$$anonfun$scala$Enumeration$$nameOf$1.apply(Enumeration.scala:183)
    at scala.collection.MapLike$class.getOrElse(MapLike.scala:122)
    at scala.collection.mutable.HashMap.getOrElse(HashMap.scala:43)
    at scala.Enumeration.scala$Enumeration$$nameOf(Enumeration.scala:183)
    at scala.Enumeration$Val.toString(Enumeration.scala:220)
    at java.lang.String.valueOf(String.java:2826)
    at scala.collection.mutable.StringBuilder.append(StringBuilder.scala:185)
    at com.arbfranklin.tinybot.strategies.CreateDistance.name(CreateDistance.scala:35)
```

**The Solution**

Add support for _accessDeclaredMembers_ in the PluginSecurityManager.
