### PR TITLE
Upgrade build definitions to latest SBT versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,4 +4,4 @@ name         := "Scalatron"
 
 version in Global := "1.1.0.2"
 
-scalaVersion := "2.9.1"
+scalaVersion := "2.9.2"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.13.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ resolvers += Resolver.url(
   new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/")
 )(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.8.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")


### PR DESCRIPTION
Hi, for opening the project with latest Intellij it is required that SBT is 0.12.4+. This pull request modifies the build definition in order to accomplish that.
