### PR TITLE
Fix publishing on Windows host

### DIFF
--- a/ScalaMarkdown/test/scala/test.scala
+++ b/ScalaMarkdown/test/scala/test.scala
@@ -15,16 +15,17 @@ object MarkdownSpec extends Specification {
     def apply(name: => String) = {
       val textFile = this.getClass.getResourceAsStream("/" + name + ".text")
       val htmlFile = this.getClass.getResourceAsStream("/" + name + ".html")
-      val text = Markdown(IOUtils.toString(textFile, "ISO-8859-1")).trim
-//      println("[%s]".format(text))
-      val html = IOUtils.toString(htmlFile, "ISO-8859-1").trim
-      val diffIndex = StringUtils.indexOfDifference(text, html)
-      val diff = StringUtils.difference(text, html)
+      val text = normalize(Markdown(IOUtils.toString(textFile, "ISO-8859-1")))
+      val expectedHtml = normalize(IOUtils.toString(htmlFile, "ISO-8859-1"))
+      val diffIndex = StringUtils.indexOfDifference(text, expectedHtml)
+      val diff = StringUtils.difference(text, expectedHtml)
       (diffIndex == -1,
           "\"" + name + "\" is fine",
           "\"" + name + "\" fails at " + diffIndex + ": " + StringUtils.abbreviate(diff, 32))
     }
   }
+
+  def normalize(s: String) : String = s.trim.replace(sys.props("line.separator"),"\n")
 
   def process = addToSusVerb("process")
 

--- a/Scalatron/src/scalatron/scalatron/impl/PluginDirectory.scala
+++ b/Scalatron/src/scalatron/scalatron/impl/PluginDirectory.scala
@@ -1,0 +1,50 @@
+package scalatron.scalatron.impl
+
+/** This material is intended as a community resource and is licensed under the
+  * Creative Commons Attribution 3.0 Unported License. Feel free to use, modify and share it.
+  */
+
+import java.io.File
+
+
+case class PluginDirectory(pluginDirectory: File) {
+  case class VersionedPlugin(version: Int, plugin: File)
+
+  val botfile_r = """ScalatronBot_(\d+)\.jar""".r
+  val botfile_f = "ScalatronBot_%d.jar"
+
+  def mostRecentPlugin: Option[File] = {
+    mostRecentPluginWithVersion.map(_.plugin)
+  }
+
+  def nextFilename: File = {
+    val nextVersion = mostRecentPluginWithVersion.map(_.version).getOrElse(0) + 1
+    val filePath = pluginDirectory.getCanonicalPath + "/" + botfile_f.format(nextVersion)
+    new File(filePath)
+  }
+
+  private def mostRecentPluginWithVersion : Option[VersionedPlugin] = {
+    val botnums = enumFiles
+
+    if (botnums.isEmpty) {
+      None
+    } else {
+      val most_recent = botnums.maxBy(_.version)
+      Some(most_recent)
+    }
+  }
+
+  private def enumFiles: Array[VersionedPlugin] = {
+    val files = pluginDirectory.listFiles()
+    val botnums = files.filter(file => botfile_r.findFirstIn(file.getName) match {
+      case Some(num) => true
+      case None => false
+    }).map(file => botfile_r.findFirstIn(file.getName) match {
+      case Some(num) => {
+        val botfile_r(num2) = file.getName
+        VersionedPlugin(num2.toInt, file)
+      }
+    })
+    botnums
+  }
+}

--- a/Scalatron/test/scalatron/scalatron/api/ScalatronApiSpec.scala
+++ b/Scalatron/test/scalatron/scalatron/api/ScalatronApiSpec.scala
@@ -182,9 +182,29 @@ class ScalatronApiSpec extends mutable.Specification
 
                 // publish the bot into the tournament plug-in directory
                 user.publish()
-                assert(new File(pluginBaseDirPath + "/ExampleUser/ScalatronBot.jar").exists())
+                assert(new File(pluginBaseDirPath + "/ExampleUser/ScalatronBot_1.jar").exists())
 
                 // ... if we now called scalatron.run, the tournament should pick up the plug-in
+
+                success
+            })
+        }
+
+        "be able to update the published jar" in {
+            runTest((scalatron: Scalatron, usersBaseDirPath: String, samplesBaseDirPath: String, pluginBaseDirPath: String, runOneStep: () => Unit) => {
+                val user = scalatron.createUser("ExampleUser", "", sourceFiles)
+                user.buildSources()
+
+                // TODO: refactor this from asserts to Specs2
+
+                // publish the bot into the tournament plug-in directory
+                user.publish()
+                assert(new File(pluginBaseDirPath + "/ExampleUser/ScalatronBot_1.jar").exists())
+
+                runOneStep()
+
+                user.publish()
+                assert(new File(pluginBaseDirPath + "/ExampleUser/ScalatronBot_2.jar").exists())
 
                 success
             })
@@ -324,7 +344,11 @@ object ScalatronApiTest
       * method, invoking it with (scalatron, usersBaseDirPath, samplesBaseDirPath, pluginBaseDirPath),
       * then shuts down the Scalatron server and deletes the temp directory.
       */
-    def runTest(test: (Scalatron, String, String, String) => Result, verbose: Boolean = false) : Result = {
+    def runTest(test: (Scalatron, String, String, String) => Result) : Result = {
+        runTest((a,b,c,d,_) => test(a,b,c,d), verbose = false)
+    }
+
+    def runTest(test: (Scalatron, String, String, String, () => Unit) => Result, verbose: Boolean = false) : Result = {
         //------------------------------------------------------------------------------------------
         // prepare environment, start server
         //------------------------------------------------------------------------------------------
@@ -344,9 +368,10 @@ object ScalatronApiTest
             val scalatron =
                 ScalatronOutward(
                     Map(
-                        ( "-users" -> usersBaseDirPath ),
-                        ( "-samples" -> samplesBaseDirPath ),
-                        ( "-plugins" -> pluginBaseDirPath )
+                        "-users" -> usersBaseDirPath,
+                        "-samples" -> samplesBaseDirPath,
+                        "-plugins" -> pluginBaseDirPath,
+                        "-steps" -> "1"
                     ),
                     actorSystem,
                     verbose
@@ -355,7 +380,7 @@ object ScalatronApiTest
             // start the server, launching the background thread(s) (e.g., compile server)
             scalatron.start()
 
-            val result = test(scalatron, usersBaseDirPath, samplesBaseDirPath, pluginBaseDirPath)
+            val result = test(scalatron, usersBaseDirPath, samplesBaseDirPath, pluginBaseDirPath, () => {scalatron.run(Map("-rounds" -> "1", "-headless" -> "yes"))})
 
             // shut down the server, terminating the background thread(s)
             scalatron.shutdown()

--- a/Scalatron/test/scalatron/scalatron/api/ScalatronApiSpec.scala
+++ b/Scalatron/test/scalatron/scalatron/api/ScalatronApiSpec.scala
@@ -363,7 +363,8 @@ object ScalatronApiTest
             result
         } finally {
             // delete the temporary directory
-            FileUtil.deleteRecursively(tmpDirPath, atThisLevel = true, verbose = verbose)
+            // Currently broken on Windows
+            //FileUtil.deleteRecursively(tmpDirPath, atThisLevel = true, verbose = verbose)
         }
     }
 

--- a/Scalatron/test/scalatron/scalatron/api/ScalatronApiSpec.scala
+++ b/Scalatron/test/scalatron/scalatron/api/ScalatronApiSpec.scala
@@ -153,13 +153,13 @@ class ScalatronApiSpec extends mutable.Specification
 
                 val sortedMessages = compileResult.messages.toArray.sortBy(_.sourceFile)
                 val msg0 = sortedMessages(0)
-                assert(msg0.sourceFile == "1.scala")
+                assert(msg0.sourceFile.contains("1.scala"))
                 assert(msg0.lineAndColumn ==(1, 1))
                 assert(msg0.severity == 2)
                 assert(msg0.multiLineMessage == "expected class or object definition")
 
                 val msg1 = sortedMessages(1)
-                assert(msg1.sourceFile == "2.scala")
+                assert(msg1.sourceFile.contains("2.scala"))
                 assert(msg1.lineAndColumn ==(1, 12))
                 assert(msg1.severity == 2)
                 assert(msg1.multiLineMessage == "expected class or object definition")

--- a/build.sbt
+++ b/build.sbt
@@ -4,4 +4,4 @@ name         := "Scalatron"
 
 version in Global := "1.1.0.2"
 
-scalaVersion := "2.9.1"
+scalaVersion := "2.9.2"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.13.6

--- a/project/build.scala
+++ b/project/build.scala
@@ -111,7 +111,7 @@ object build extends Build {
     lazy val samples = (IO.listFiles(file("Scalatron") / "samples")) filter (!_.isFile) map {
         sample: File => sample.getName -> Project(sample.getName.replace(" ",""), sample, settings = Defaults.defaultSettings ++ Seq (
             scalaSource in Compile <<= baseDirectory / "src",
-            artifactName in packageBin := ((_, _, _) => "ScalatronBot.jar")
+            artifactName in packageBin := ((_, _, _) => "ScalatronBot_1.jar")
            , scalaVersion := compilerVersion
         ))
     } toMap
@@ -145,17 +145,17 @@ object build extends Build {
         }
 
         val distSamples = distDir / "samples"
-        def sampleJar(sample: Project) = sample.base / ("target/scala-%s/ScalatronBot.jar" format version)
+        def sampleJar(sample: Project) = sample.base / ("target/scala-%s/ScalatronBot_1.jar" format version)
         for (sample <- samples.values) {
             if (sampleJar(sample).exists) {
                 println("Copying " + sample.base)
                 IO.copyDirectory(sample.base / "src", distSamples / sample.base.getName / "src")
-                IO.copyFile(sampleJar(sample), distSamples / sample.base.getName / "ScalatronBot.jar")
+                IO.copyFile(sampleJar(sample), distSamples / sample.base.getName / "ScalatronBot_1.jar")
             }
         }
 
         println ("Copying Reference bot to /bots directory...")
-        IO.copyFile(sampleJar(referenceBot), distDir / "bots" / "Reference" / "ScalatronBot.jar")
+        IO.copyFile(sampleJar(referenceBot), distDir / "bots" / "Reference" / "ScalatronBot_1.jar")
 
 
         def markdown(docDir: File, htmlDir: File) = {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ resolvers += Resolver.url(
   new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/")
 )(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.8.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")


### PR DESCRIPTION
This fixes issue #48, as well as some other necessities to get Scalatron building on Windows with IntelliJ (for example pull request #67).

The server will now not try to delete running plugin bots, because that will fail under Windows. Instead, all versions are kept, and the newest plugin is loaded each round. No attempt is made to unload or remove previous versions.

I know of at least two issues with this fix:
1. It might not be a good idea in an untrusted environment, because a user could keep publishing to try and exhaust memory or disk space of the host.
2. The cleanup part of the tests (ScalatronApiSpec.scala) has the same issue and also couldn't be deleted, causing tests to fail. This was solved by simply disabling cleanup.

The road not traveled:
To solve these issues, you'd have to be able to close the plugin jars file handles at runtime. This might be doable with URLClassLoader.close at the right time, but that is way too fiddly for my little brain.
